### PR TITLE
Maintenance Update

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,5 +51,5 @@ jobs:
           done
 
       - name: Run e2e tests
-        run: go test -timeout 30m ./test/e2e/...
+        run: go test -timeout 90m ./test/e2e/...
         

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,7 +51,7 @@ jobs:
           done
 
       - name: Run e2e tests (VMs)
-        run: go test -timeout 90m ./test/e2e/v2/gpu_groups ./test/e2e/v2/gpu_leases
+        run: go test -timeout 90m ./test/e2e/v2/gpu_groups ./test/e2e/v2/gpu_leases ./test/e2e/v2/vms
 
       - name: Run e2e tests (Deployments)
         run: go test -timeout 90m ./test/e2e/v2/deployments
@@ -60,7 +60,10 @@ jobs:
         run: go test -timeout 90m ./test/e2e/v2/sms
 
       - name: Run e2e tests (Jobs)
-        run: go test -timeout 90m ./test/e2e/v2/jobs ./test/e2e/v2/resource_migrations
+        run: go test -timeout 90m ./test/e2e/v2/jobs
+
+      - name: Run e2e tests (Resource Migrations)
+        run: go test -timeout 90m ./test/e2e/v2/resource_migrations
 
       - name: Run e2e tests (Users)
         run: go test -timeout 90m ./test/e2e/v2/users ./test/e2e/v2/teams ./test/e2e/v2/notifications

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,6 +50,20 @@ jobs:
               sleep 1
           done
 
-      - name: Run e2e tests
-        run: go test -timeout 90m ./test/e2e/...
-        
+      - name: Run e2e tests (VMs)
+        run: go test -timeout 90m ./test/e2e/v2/gpu_groups ./test/e2e/v2/gpu_leases
+
+      - name: Run e2e tests (Deployments)
+        run: go test -timeout 90m ./test/e2e/v2/deployments
+
+      - name: Run e2e tests (SMs)
+        run: go test -timeout 90m ./test/e2e/v2/sms
+
+      - name: Run e2e tests (Jobs)
+        run: go test -timeout 90m ./test/e2e/v2/jobs ./test/e2e/v2/resource_migrations
+
+      - name: Run e2e tests (Users)
+        run: go test -timeout 90m ./test/e2e/v2/users ./test/e2e/v2/teams ./test/e2e/v2/notifications
+
+      - name: Run e2e tests (System)
+        run: go test -timeout 90m ./test/e2e/v2/zones

--- a/dto/v2/body/vm_port.go
+++ b/dto/v2/body/vm_port.go
@@ -30,8 +30,8 @@ type CustomDomainRead struct {
 }
 
 type HttpProxyRead struct {
-	Name         string            `json:"name" bson:"name,omitempty" binding:"required,rfc1035,min=3,max=30"`
-	URL          *string           `json:"url,omitempty,omitempty"`
+	Name         string            `json:"name" bson:"name"`
+	URL          *string           `json:"url,omitempty" bson:"url,omitempty"`
 	CustomDomain *CustomDomainRead `json:"customDomain,omitempty" bson:"customDomain,omitempty"`
 }
 

--- a/models/config/config.go
+++ b/models/config/config.go
@@ -67,6 +67,7 @@ type ConfigType struct {
 		PrivilegedGPUs []string `yaml:"privilegedGpus"`
 		ExcludedHosts  []string `yaml:"excludedHosts"`
 		ExcludedGPUs   []string `yaml:"excludedGpus"`
+		AddMock        bool     `yaml:"addMock"`
 	} `yaml:"gpu"`
 
 	Registry struct {
@@ -100,16 +101,6 @@ type ConfigType struct {
 		URL      string `yaml:"url"`
 		Password string `yaml:"password"`
 	}
-
-	SysApi struct {
-		URL      string `yaml:"url"`
-		User     string `yaml:"user"`
-		Password string `yaml:"password"`
-		ClientID string `yaml:"clientId"`
-		// UseMock is a flag that indicates whether the sys-api should be mocked
-		// This is useful for testing purposes, since the sys-api cannot be run locally
-		UseMock bool `yaml:"useMock"`
-	} `yaml:"sys-api"`
 
 	Harbor struct {
 		URL           string `yaml:"url"`

--- a/models/model/deployment.go
+++ b/models/model/deployment.go
@@ -76,24 +76,6 @@ func (deployment *Deployment) GetURL(externalPort *int) *string {
 	return nil
 }
 
-// GetCustomDomainURL returns the custom domain URL of the deployment.
-// If the app does not have a custom domain, it will return nil.
-// This method does not check whether the custom domain is active, and does
-// not check if the ingress exists.
-func (deployment *Deployment) GetCustomDomainURL() *string {
-	app := deployment.GetMainApp()
-	if app == nil {
-		return nil
-	}
-
-	if app.CustomDomain != nil && len(app.CustomDomain.Domain) > 0 {
-		url := fmt.Sprintf("https://%s", app.CustomDomain.Domain)
-		return &url
-	}
-
-	return nil
-}
-
 // Ready returns true if the deployment is not being created or deleted.
 func (deployment *Deployment) Ready() bool {
 	return !deployment.DoingActivity(ActivityBeingCreated) && !deployment.DoingActivity(ActivityBeingDeleted)

--- a/models/model/deployment_convert.go
+++ b/models/model/deployment_convert.go
@@ -87,9 +87,13 @@ func (deployment *Deployment) ToDTO(smURL *string, externalPort *int, teams []st
 
 	var customDomain *body.CustomDomainRead
 	if app.CustomDomain != nil {
+		extPortStr := ""
+		if externalPort != nil && *externalPort != 443 {
+			extPortStr = fmt.Sprintf(":%d", *externalPort)
+		}
 		customDomain = &body.CustomDomainRead{
 			Domain: app.CustomDomain.Domain,
-			URL:    fmt.Sprintf("https://%s", app.CustomDomain.Domain),
+			URL:    fmt.Sprintf("https://%s%s", app.CustomDomain.Domain, extPortStr),
 			Status: app.CustomDomain.Status,
 			Secret: app.CustomDomain.Secret,
 		}

--- a/pkg/app/status_codes/code.go
+++ b/pkg/app/status_codes/code.go
@@ -21,6 +21,7 @@ const (
 	ResourceMountFailed      = 10040
 	ResourceImagePullFailed  = 10041
 	ResourceDisabled         = 10042
+	ResourceUnschedulable    = 10043
 
 	JobPending    = 10140
 	JobFinished   = 10141
@@ -56,6 +57,7 @@ var MsgFlags = map[int]string{
 	ResourceMountFailed:      "resourceMountFailed",
 	ResourceImagePullFailed:  "resourceImagePullFailed",
 	ResourceDisabled:         "resourceDisabled",
+	ResourceUnschedulable:    "resourceUnschedulable",
 
 	JobPending:    "pending",
 	JobRunning:    "running",

--- a/pkg/db/key_value/client.go
+++ b/pkg/db/key_value/client.go
@@ -107,7 +107,7 @@ func (client *Client) SetUpExpirationListener(ctx context.Context, pattern strin
 				err := handler(msg.Payload)
 				if err != nil {
 					utils.PrettyPrintError(fmt.Errorf("failed to handle expired key event for key %s. details: %w", msg.Payload, err))
-					return
+					continue
 				}
 			}
 		}

--- a/pkg/services/logger/pod_event_listener.go
+++ b/pkg/services/logger/pod_event_listener.go
@@ -44,6 +44,7 @@ func PodEventListener(ctx context.Context) error {
 
 			if !exists {
 				// Clean up the keys
+				log.Printf("Pod %s not longer exists. Cleaning up keys", podName)
 				_ = kvc.Del(LogKey(podName))
 				_ = kvc.Del(LastLogKey(podName))
 				_ = kvc.Del(OwnerLogKey(podName))

--- a/pkg/services/status_update/vm_status_listener.go
+++ b/pkg/services/status_update/vm_status_listener.go
@@ -86,6 +86,8 @@ func parseVmStatus(status *model.VmStatus) string {
 		statusCode = status_codes.ResourceStopping
 	case "Terminating":
 		statusCode = status_codes.ResourceDeleting
+	case "ErrorUnschedulable":
+		statusCode = status_codes.ResourceUnschedulable
 	case "CrashLoopBackOff", "Unknown", "Unschedulable", "ErrImagePull", "ImagePullBackOff", "PvcNotFound", "DataVolumeError":
 		statusCode = status_codes.ResourceError
 	default:

--- a/pkg/services/synchronize/fetch_gpu.go
+++ b/pkg/services/synchronize/fetch_gpu.go
@@ -157,11 +157,54 @@ func listLatestGPUs() (*body.SystemGpuInfo, error) {
 		return nil, makeError(err)
 	}
 
+	var result *body.SystemGpuInfo
 	if len(systemGpuInfo) > 0 {
-		return &systemGpuInfo[0].GpuInfo, nil
+		result = &systemGpuInfo[0].GpuInfo
 	}
 
-	return nil, nil
+	if config.Config.GPU.AddMock {
+		// Add one mock GPUs in each zone
+		for _, zone := range config.Config.EnabledZones() {
+			if result == nil {
+				result = &body.SystemGpuInfo{}
+			}
+
+			result.HostGpuInfo = append(result.HostGpuInfo, body.HostGpuInfo{
+				HostBase: body.HostBase{
+					Name:        "Mock Host 1",
+					DisplayName: "Mock Host 1",
+					Zone:        zone.Name,
+				},
+				GPUs: []host_api.GpuInfo{{
+					Name:     "Mock GPU 1",
+					Vendor:   "NVIDIA",
+					VendorID: "10de",
+					DeviceID: "1eb0",
+				}, {
+					Name:     "Mock GPU 2",
+					Vendor:   "NVIDIA",
+					VendorID: "10de",
+					DeviceID: "2230",
+				}},
+			})
+
+			result.HostGpuInfo = append(result.HostGpuInfo, body.HostGpuInfo{
+				HostBase: body.HostBase{
+					Name:        "Mock Host 2",
+					DisplayName: "Mock Host 2",
+					Zone:        zone.Name,
+				},
+				GPUs: []host_api.GpuInfo{{
+					Name:     "Mock GPU 1",
+					Vendor:   "NVIDIA",
+					VendorID: "10de",
+					DeviceID: "1eb0",
+				}},
+			})
+		}
+	}
+
+	return result, nil
 }
 
 func createGpuGroupName(gpu *host_api.GpuInfo) *string {

--- a/pkg/subsystems/k8s/status.go
+++ b/pkg/subsystems/k8s/status.go
@@ -90,7 +90,9 @@ func (client *Client) deploymentStatusWatcher(ctx context.Context, handler func(
 					}
 				}
 			case <-recreateInterval:
-				watcher.Stop()
+				if watcher != nil {
+					watcher.Stop()
+				}
 				watcher, err = setupDeploymentWatcher(client.Namespace)
 				if err != nil {
 					log.Println("Failed to restart Deployment status watcher, sleeping for 10 seconds before retrying")
@@ -141,7 +143,9 @@ func (client *Client) vmStatusWatcher(ctx context.Context, handler func(string, 
 					handler(vmStatus.Name, vmStatus)
 				}
 			case <-recreateInterval:
-				watcher.Stop()
+				if watcher != nil {
+					watcher.Stop()
+				}
 				watcher, err = setupVmWatcher(client.Namespace)
 				if err != nil {
 					log.Println("Failed to restart VM status watcher, sleeping for 10 seconds before retrying")
@@ -192,7 +196,9 @@ func (client *Client) vmiStatusWatcher(ctx context.Context, handler func(string,
 					handler(vmiStatus.Name, vmiStatus)
 				}
 			case <-recreateInterval:
-				watcher.Stop()
+				if watcher != nil {
+					watcher.Stop()
+				}
 				watcher, err = setupVmWatcher(client.Namespace)
 				if err != nil {
 					log.Println("Failed to restart VM instance status watcher, sleeping for 10 seconds before retrying")
@@ -340,7 +346,9 @@ func (client *Client) eventWatcher(ctx context.Context, handler func(string, int
 					}(e)
 				}
 			case <-recreateInterval:
-				watcher.Stop()
+				if watcher != nil {
+					watcher.Stop()
+				}
 				watcher, err = setupEventWatcher(client.Namespace)
 				if err != nil {
 					log.Println("Failed to restart Event status watcher, sleeping for 10 seconds before retrying")

--- a/scripts/local/config.yml.tmpl
+++ b/scripts/local/config.yml.tmpl
@@ -70,6 +70,7 @@ gpu:
   privilegedGpus:
   excludedHosts:
   excludedGpus:
+  addMock: true
 
 deployment:
   defaultZone: local
@@ -164,13 +165,6 @@ mongodb:
 redis:
   url: $redis_url
   password: $redis_password
-
-sys-api:
-  url: 
-  user: 
-  password: 
-  clientId: 
-  useMock: true
 
 harbor:
   url: $harbor_url

--- a/service/v2/vms/gpu_leases/gpu_lease_service.go
+++ b/service/v2/vms/gpu_leases/gpu_lease_service.go
@@ -41,8 +41,8 @@ func (c *Client) Get(id string, opts ...opts.GetGpuLeaseOpts) (*model.GpuLease, 
 			return nil, makeError(err)
 		}
 
-		if leaseByUserID == nil {
-			return nil, nil
+		if leaseByUserID != nil {
+			return leaseByUserID, nil
 		}
 
 		// 3. User has access to the parent VM through a team

--- a/test/acc/common.go
+++ b/test/acc/common.go
@@ -11,6 +11,10 @@ import (
 	"github.com/google/uuid"
 )
 
+const (
+	VmTestsEnabled = false
+)
+
 func Setup() {
 	err := log.SetupLogger(mode.Test)
 	if err != nil {

--- a/test/acc/subsystems/k8s/vm_test.go
+++ b/test/acc/subsystems/k8s/vm_test.go
@@ -3,10 +3,15 @@ package k8s
 import (
 	"github.com/stretchr/testify/assert"
 	"go-deploy/test"
+	"go-deploy/test/acc"
 	"testing"
 )
 
 func TestCreateVM(t *testing.T) {
+	if !acc.VmTestsEnabled {
+		t.Skip("vm tests are disabled")
+	}
+
 	t.Parallel()
 
 	c, _ := withContext(t)
@@ -14,6 +19,10 @@ func TestCreateVM(t *testing.T) {
 }
 
 func TestUpdateVM(t *testing.T) {
+	if !acc.VmTestsEnabled {
+		t.Skip("vm tests are disabled")
+	}
+
 	t.Parallel()
 
 	c, _ := withContext(t)

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -25,8 +25,8 @@ const (
 	CheckInterval = 1 * time.Second
 	MaxChecks     = 900 // 900 * CheckInterval (1) seconds = 15 minutes
 
-	// V2TestsEnabled flag is used temporarily to enable V2 tests until V2 zone is fully operational
-	V2TestsEnabled = true
+	// VmTestsEnabled flag is used temporarily to enable V2 tests until V2 zone is fully operational
+	VmTestsEnabled = true
 )
 
 func GetUserID(user string) string {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -25,8 +25,7 @@ const (
 	CheckInterval = 1 * time.Second
 	MaxChecks     = 3600 // 1 hour
 
-	// VmTestsEnabled flag is used temporarily to enable V2 tests until V2 zone is fully operational
-	VmTestsEnabled = true
+	VmTestsEnabled = false
 )
 
 func GetUserID(user string) string {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -23,7 +23,7 @@ const (
 
 	TestDomain    = "test-deploy.saffronbun.com"
 	CheckInterval = 1 * time.Second
-	MaxChecks     = 900 // 900 * CheckInterval (1) seconds = 15 minutes
+	MaxChecks     = 3600 // 1 hour
 
 	// VmTestsEnabled flag is used temporarily to enable V2 tests until V2 zone is fully operational
 	VmTestsEnabled = true

--- a/test/e2e/v2/deployment_utils.go
+++ b/test/e2e/v2/deployment_utils.go
@@ -197,7 +197,7 @@ func WithDeployment(t *testing.T, requestBody body.DeploymentCreate, user ...str
 	if requestBody.CustomDomain != nil {
 		punyEncoded, err := idna.New().ToASCII("https://" + *requestBody.CustomDomain)
 		assert.NoError(t, err, "custom domain was not puny encoded")
-		assert.Equal(t, punyEncoded, deploymentRead.CustomDomain.URL)
+		assert.Contains(t, deploymentRead.CustomDomain.URL, punyEncoded, "custom domain was not set")
 	}
 
 	return deploymentRead, deploymentCreated.JobID

--- a/test/e2e/v2/gpu_groups/routes_test.go
+++ b/test/e2e/v2/gpu_groups/routes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if e2e.V2TestsEnabled {
+	if e2e.VmTestsEnabled {
 		e2e.Setup()
 		code := m.Run()
 		e2e.Shutdown()

--- a/test/e2e/v2/gpu_leases/routes_test.go
+++ b/test/e2e/v2/gpu_leases/routes_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if e2e.V2TestsEnabled {
+	if e2e.VmTestsEnabled {
 		e2e.Setup()
 		code := m.Run()
 		e2e.Shutdown()

--- a/test/e2e/v2/vms/routes_test.go
+++ b/test/e2e/v2/vms/routes_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if e2e.V2TestsEnabled {
+	if e2e.VmTestsEnabled {
 		e2e.Setup()
 		code := m.Run()
 		e2e.Shutdown()

--- a/test/e2e/v2/vms/routes_test.go
+++ b/test/e2e/v2/vms/routes_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestList(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 
 	queries := []string{
 		"?page=1&pageSize=10",
@@ -38,7 +38,7 @@ func TestList(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 
 	requestBody := body.VmCreate{
 		Name:         e2e.GenName(),
@@ -60,7 +60,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestCreateWithInvalidBody(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 
 	longName := body.VmCreate{
 		Name:     "e2e-",
@@ -199,7 +199,7 @@ func TestCreateWithInvalidBody(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 
 	vm := v2.WithDefaultVM(t)
 
@@ -246,7 +246,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestCreateShared(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 
 	vm := v2.WithDefaultVM(t)
 	team := v2.WithTeam(t, body.TeamCreate{
@@ -273,7 +273,7 @@ func TestCreateShared(t *testing.T) {
 }
 
 func TestAction(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 
 	actions := []string{"stop", "start", "restart"}
 	vm := v2.WithDefaultVM(t)
@@ -285,7 +285,7 @@ func TestAction(t *testing.T) {
 }
 
 func TestInvalidAction(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 
 	actions := []string{"some command", "invalid"}
 


### PR DESCRIPTION
- Increase e2e timeout for test from 30m to 90m
- Split e2e tests to multiple sections
- Fix inconsistent read objects for VM http proxy
- Fix bug where GPU leases could disappear from read
- Add mock support for GPU groups

Resolves https://github.com/kthcloud/go-deploy/issues/639
Resolves https://github.com/kthcloud/go-deploy/issues/623
Resolves https://github.com/kthcloud/go-deploy/issues/582