### PR TITLE
Fix local script storage directory typo in README?

### DIFF
--- a/scripts/local/README.md
+++ b/scripts/local/README.md
@@ -43,7 +43,7 @@ The following services will be installed in the Kubernetes cluster:
 
 
 ### Storage
-The setup script creates a local directory `$HOME/go-deploy-storage/go-deploy-dev` to store the data for the NFS server.
+The setup script creates a local directory `$HOME/go-deploy-data/go-deploy-dev` to store the data for the NFS server.
 
 This is done using a mix of manually provisioning the storage and using the NFS CSI driver to create a PersistentVolumeClaim.
 


### PR DESCRIPTION
# Fix storage directory typo in local script README?

HI, I think the storage directory in the README is wrong, when i ran the script it created this directory:
![image](https://github.com/kthcloud/go-deploy/assets/112874974/1dc5a84d-4b2a-4d2f-9c3a-866dccc3b28a)

But i might be wrong, I haven't gotten the nfs working yet : (
