### PR TITLE
Added gha runner cache in ci config

### DIFF
--- a/models/model/github_ci.go
+++ b/models/model/github_ci.go
@@ -16,11 +16,13 @@ type On struct {
 }
 
 type With struct {
-	Registry string `yaml:"registry,omitempty"`
-	Username string `yaml:"username,omitempty"`
-	Password string `yaml:"password,omitempty"`
-	Push     bool   `yaml:"push,omitempty"`
-	Tags     string `yaml:"tags,omitempty"`
+	Registry  string `yaml:"registry,omitempty"`
+	Username  string `yaml:"username,omitempty"`
+	Password  string `yaml:"password,omitempty"`
+	Push      bool   `yaml:"push,omitempty"`
+	Tags      string `yaml:"tags,omitempty"`
+	CacheTo   string `yaml:"cache-to,omitempty"`
+	CacheFrom string `yaml:"cache-from,omitempty"`
 }
 
 type Steps struct {

--- a/service/v2/deployments/ci_config_service.go
+++ b/service/v2/deployments/ci_config_service.go
@@ -8,8 +8,9 @@ import (
 	"go-deploy/service/errors"
 	"go-deploy/service/v2/deployments/opts"
 	"go-deploy/utils/subsystemutils"
-	"gopkg.in/yaml.v3"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // GetCiConfig returns the CI config for the deployment.
@@ -65,8 +66,10 @@ func (c *Client) GetCiConfig(id string) (*body.CiConfig, error) {
 					Name: "Build and push",
 					Uses: "docker/build-push-action@v5",
 					With: model.With{
-						Push: true,
-						Tags: tag,
+						Push:      true,
+						Tags:      tag,
+						CacheFrom: "gha",
+						CacheTo:   "type=gha,mode=max",
 					},
 				},
 			},


### PR DESCRIPTION
Added cache config for the CI GHA workflows that are generated.

It will save cache on the GHA runner so build times are reduced.

Here is how the workflow file will look, (the two last lines are new).

```yaml
name: kthcloud-ci
"on":
  push:
    branches:
      - main
  workflow_dispatch:
jobs:
  docker:
    runs-on: ubuntu-latest
    steps:
      - name: Login to Docker Hub
        uses: docker/login-action@v3
        with:
          registry: registry.cloud.cbh.kth.se
          username: ${{ secrets.DOCKER_USERNAME }}
          password: ${{ secrets.DOCKER_PASSWORD }}
      - name: Build and push
        uses: docker/build-push-action@v5
        with:
          push: true
          tags: ${{ secrets.DOCKER_TAG }}
          cache-from: gha
          cache-to: type=gha,mode=max
```

[`cache-to`](https://docs.docker.com/reference/cli/docker/buildx/build/#cache-to)
[`cache-from`](https://docs.docker.com/reference/cli/docker/buildx/build/#cache-from)