### PR TITLE
Fix openapi spec to use servers for adding the correct basepath for /deploy

### DIFF
--- a/docs/api/v2/handlers/serve_fs.go
+++ b/docs/api/v2/handlers/serve_fs.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/swaggo/swag/v2"
+	v2 "github.com/kthcloud/go-deploy/docs/api/v2"
 
 	swaggerfiles "github.com/swaggo/files/v2"
 )
@@ -40,11 +40,7 @@ func ServeDocs(basePath string) func(ctx *gin.Context) {
 		}
 
 		if strings.TrimPrefix(filePath, "/") == "doc.json" {
-			doc, err := swag.ReadDoc("V2")
-			if err != nil {
-				ctx.String(http.StatusInternalServerError, "Failed to load documentation")
-				return
-			}
+			doc := v2.SwaggerInfoV2.ReadDoc()
 			ctx.Header("Cache-Control", "public, max-age=3600")
 			ctx.Data(http.StatusOK, "application/json", []byte(doc))
 			return

--- a/docs/api/v2/util/servers.go
+++ b/docs/api/v2/util/servers.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	docsV2 "github.com/kthcloud/go-deploy/docs/api/v2"
+
+	"github.com/swaggo/swag/v2"
+)
+
+type ExtendedSpec struct {
+	swag.Spec
+	Servers []struct {
+		URL         string `json:"url"`
+		Description string `json:"description,omitempty"`
+	} `json:"servers,omitempty"`
+}
+
+func UpdateSwaggerServers(servers ...string) error {
+	// Create the server JSON part dynamically
+	var serversJSON string
+	for _, server := range servers {
+		serversJSON += fmt.Sprintf(`
+    {
+      "url": "%s",
+      "description": ""
+    },`, server)
+	}
+
+	// Remove the last comma (to make it valid JSON) and add it in the correct location
+	if len(serversJSON) > 0 {
+		serversJSON = serversJSON[:len(serversJSON)-1]
+	}
+
+	// Find the last closing brace in the Swagger template and inject servers JSON before it
+	swaggerTemplate := docsV2.SwaggerInfoV2.SwaggerTemplate
+	closeBraceIndex := strings.LastIndex(swaggerTemplate, "}")
+	if closeBraceIndex == -1 {
+		return fmt.Errorf("could not find closing brace in Swagger template")
+	}
+
+	// Insert the servers JSON right before the closing brace
+	swaggerTemplate = swaggerTemplate[:closeBraceIndex] + ",\n  \"servers\": [" + serversJSON + "]" + swaggerTemplate[closeBraceIndex:]
+
+	// Update the Swagger template
+	docsV2.SwaggerInfoV2.SwaggerTemplate = swaggerTemplate
+	return nil
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	docsV2 "github.com/kthcloud/go-deploy/docs/api/v2"
 	docsV2Handlers "github.com/kthcloud/go-deploy/docs/api/v2/handlers"
+	docsV2ServerUtil "github.com/kthcloud/go-deploy/docs/api/v2/util"
 	"github.com/kthcloud/go-deploy/models/mode"
 	"github.com/kthcloud/go-deploy/pkg/auth"
 	"github.com/kthcloud/go-deploy/pkg/config"
@@ -69,6 +70,11 @@ func NewRouter() *gin.Engine {
 	docsV2.SwaggerInfoV2.BasePath = basePath
 	docsV2.SwaggerInfoV2.Host = ""
 	docsV2.SwaggerInfoV2.Schemes = []string{"http", "https"}
+
+	// Update openapi spec to have the correct basepath, since openapi 3.+ doesnt use basepath and uses servers instead
+	if err := docsV2ServerUtil.UpdateSwaggerServers(basePath); err != nil {
+		log.Fatalln(err)
+	}
 
 	//public.GET("/v2/docs/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
 	public.GET("/v2/docs/*any", docsV2Handlers.ServeDocs(basePath+"/v2/docs"))


### PR DESCRIPTION
Openapi 3.+ doesn't use basepath and instead uses `servers` this update will make sure that the correct basepath is appended on to the api path.